### PR TITLE
Remove page numbering for Ehrenwort

### DIFF
--- a/build/template.tex
+++ b/build/template.tex
@@ -64,6 +64,7 @@
 
 % EHRENWÖRTLICHE ERKLÄRUNG
 \pagestyle{empty}
+\pagenumbering{gobble}
 \section*{Ehrenwörtliche Erklärung}
 \addcontentsline{toc}{section}{Ehrenwörtliche Erklärung}
 \input{build/ehrenwort.tex}


### PR DESCRIPTION
ToC should not contain a page number for Ehrenwort.

That Gobble tag somehow got lost during restructure.