### PR TITLE
Add \supercite command

### DIFF
--- a/build/components/alphabetic-ibid.cbx
+++ b/build/components/alphabetic-ibid.cbx
@@ -24,6 +24,17 @@
 	}}}
 }
 
+\newbibmacro*{cite-clean}{%
+	{\printtext[bibhyperref]{\printtext{%
+		\printfield{labelprefix}%
+		\printfield{labelalpha}%
+		\printfield{extraalpha}%
+		\ifbool{bbx:subentry} {
+			\printfield{entrysetcount}
+		}
+	}}}
+}
+
 \newbibmacro*{cite:ibid}{%
 	\printtext[bibhyperref]{\biblstring[\mkibid]{ibidem}}%
 	\ifloccit
@@ -41,6 +52,12 @@
 	{\usebibmacro{citeindex}{\usebibmacro{cite}}}
 	{\multicitedelim}
 	{\usebibmacro{postnote}}
+
+\DeclareCiteCommand{\supercite}[\textsuperscript]
+	{\usebibmacro{prenote}}
+	{\usebibmacro{citeindex}{\bibleftbracket\usebibmacro{cite-clean}\usebibmacro{postnote}}\bibrightbracket}
+	{\multicitedelim}
+	{}
 
 \DeclareFieldFormat{url}{\newline\url{#1}}
 \DeclareFieldFormat

--- a/build/components/alphabetic-ibid.cbx
+++ b/build/components/alphabetic-ibid.cbx
@@ -55,7 +55,7 @@
 
 \DeclareCiteCommand{\supercite}[\textsuperscript]
 	{\usebibmacro{prenote}}
-	{\usebibmacro{citeindex}{\bibleftbracket\usebibmacro{cite-clean}\usebibmacro{postnote}}\bibrightbracket}
+	{\usebibmacro{citeindex}{\bibleftbracket\usebibmacro{cite-clean}\usebibmacro{postnote}}\unspace\bibrightbracket}
 	{\multicitedelim}
 	{}
 


### PR DESCRIPTION
`\supercite[postnote]{id}` fügt ein alphabetisches Zitat im Superscript ein.
![image](https://user-images.githubusercontent.com/11728465/90261424-36b68200-de4d-11ea-88b7-b1e184fc7c9e.png)

closes #59 