### PR TITLE
Remove itemize config

### DIFF
--- a/build/template.tex
+++ b/build/template.tex
@@ -20,7 +20,6 @@
 	pdftitle={\CTITLE},
 	pdfauthor={\CAUTHOR}
 }
-\setlist[itemize,1]{label=\faAngleRight}
 
 \addbibresource	{../literatur.bib}
 \graphicspath	{{../assets/img/}}


### PR DESCRIPTION
Das Symbol, das hier konfiguriert wird, wird nicht nicht geladen. Dazu müsste man das Font-Awesome package installieren. 
Deswegen sollte man das standardmäßig wahrscheinlich rausnehmen.