### PR TITLE
Change paragraph indentation back to defaults

### DIFF
--- a/build/components/setup.tex
+++ b/build/components/setup.tex
@@ -1,7 +1,5 @@
 % DOCUMENT SETUP
 \onehalfspacing
-\setlength		{\parindent}{0cm} % Default is 15pt.
-\setlength		{\parskip}{0.5em}
 \widowpenalty10000
 \clubpenalty10000
 


### PR DESCRIPTION
Ich hatte anfangs den Indent eines Abschnitts entfernt und dafür einen vertikalen Abstand eingebaut.
Finde das ehrlich gesagt aber nicht mehr sonderlich schön und würde lieber wieder das Standardverhalten wiederherstellen.

So sieht das ganze dann aus:
![image](https://user-images.githubusercontent.com/11728465/135154524-ba50b127-ffa0-4dfb-b29b-d649abe4aff8.png)
