### PR TITLE
Fix acro indentation

### DIFF
--- a/build/components/setup.tex
+++ b/build/components/setup.tex
@@ -130,10 +130,31 @@
 }
 \makeatother
 
+% Standard Abkürzungsverzeichnis überschreiben -> einheitliche Einrückung
+\RenewAcroTemplate[list]{description}{%
+    \acronymsmapT{%
+        \AcroAddRow{%
+        \acrowrite{short}%
+        &
+        \acrowrite{long}%
+        \acropages
+            {\acrotranslate{page}\nobreakspace}%
+            {\acrotranslate{pages}\nobreakspace}%
+        \tabularnewline
+        }%
+    }%
+    \acroheading
+    \acropreamble
+    \begin{tabular}{ll}
+        \AcronymTable
+    \end{tabular}
+}
+
 % Abkürzungsverzeichnis SETUP
 \acsetup{
 	list/heading = section*,
 	list/name = {Abkürzungsverzeichnis},
+    list/template = description,
 	make-links = true,
 	link-only-first = false
 }

--- a/build/components/setup.tex
+++ b/build/components/setup.tex
@@ -134,12 +134,13 @@
 \RenewAcroTemplate[list]{description}{%
     \acronymsmapT{%
         \AcroAddRow{%
-        \acrowrite{short}%
+        \textbf{\acrowrite{short}}%
         &
         \acrowrite{long}%
         \acropages
             {\acrotranslate{page}\nobreakspace}%
             {\acrotranslate{pages}\nobreakspace}%
+        \vspace{10pt}
         \tabularnewline
         }%
     }%

--- a/build/components/setup.tex
+++ b/build/components/setup.tex
@@ -145,7 +145,8 @@
     }%
     \acroheading
     \acropreamble
-    \begin{tabular}{ll}
+    \noindent
+    \begin{tabular}{@{}ll}
         \AcronymTable
     \end{tabular}
 }


### PR DESCRIPTION
Custom acro template definieren -> acro liste wird nun gleichmäßig indentiert.

Das spacing zwischen Überschrift und der Liste ist allerdings noch nicht ganz korrekt, oder kommt mir das nur so vor? 🤔

Closes #110