### PR TITLE
Anlagen erlauben nur figure und table

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,7 +408,7 @@ Für mehr Informationen kann die [Acro Package Documentation](https://mirror.phy
 
 - Anlagen werden in der anlagen.tex hinterlegt.
   - hierbei ist zu beachten:
-    - die Anlage muss sich in einer Umgebung vom Typ `figure` oder `table` befinden
+    - die Anlage muss sich in einer Umgebung vom Typ `figure`, `table` oder `longfigure` befinden
     - die Anlage benötigt eine Beschriftung `\caption{}`
   - ein Label ist für eine automatische Verknüpfung im Anlagenverzeichnis nicht nötig
   - der vorgefertigte Befehl `\dhgefigure`, kann verwendet werden, da dieser beide Anforderungen erfüllt
@@ -424,6 +424,12 @@ Beispiel:
     \end{tabular}
 \end{table}
 ```
+
+### Longfigure
+
+Damit auch nicht-Floats in den Anlagen möglich sind, gibt es die `longfigure`-Environment.
+Diese verhält sich im Grunde wie `figure`. Der Inhalt darf jedoch über Seitengrenzen hinweg gehen.
+Das ist besonders für Code-Beispiele für den Anhang praktisch.
 
 # Code mit Minted einfügen
 

--- a/build/components/com.tex
+++ b/build/components/com.tex
@@ -71,6 +71,8 @@
 	{\name\protect\numberline{\theanlagen}\quad#1}\par
 }
 
+\newenvironment{longfigure}{\captionsetup{type=figure}}{}
+
 \newtotcounter{anlagenentries}
 \newcommand{\renewFigTabCap} {
 	% caption ruft jetzt \ATA{} auf, welches das jeweilige Objekt zum "Anlageverzeichnis" hinzufügt
@@ -83,6 +85,9 @@
 
 	\let\oldFig=\figure
 	\renewcommand{\figure}{\def\typeOfCap{fig}\stepcounter{anlagenentries}\oldFig}
+
+	\let\oldLongFig=\longfigure
+	\renewcommand{\longfigure}{\def\typeOfCap{fig}\stepcounter{anlagenentries}\oldLongFig}
 }
 
 % Formatierung der Bachelorarbeit: Autorreferat und Thesenblatt


### PR DESCRIPTION
Eine recht einfache Lösung.

Es wird eine nicht-float figure environment definiert: `longfigure`
Diese kann wie eine ganz normale figure environment verwendet werden, kann jedoch über Seitengrenzen hinweg gehen.

Funktioniert auf jeden Fall, wäre jedoch die Frage, ob es nicht eine elegantere Lösung gibt.

- [x] Solution
- [x] Documentation

Closes #118 