### PR TITLE
adjust tests, thus fix compiler warnings

### DIFF
--- a/build/tests/anlagen.tex
+++ b/build/tests/anlagen.tex
@@ -6,11 +6,11 @@
     \end{tabular}
 \end{table}
 
-\dhgefigure[h]{img}{scale=0.25}{Ein Testbild}{fig:test}[Xarticle][S. 17ff]
+\dhgefigure[h]{img}{scale=0.25}{Ein Testbild}{fig:anlagentest}[Xmisc][S. 17ff]
 
 \begin{figure}[H]
     \centering
     \caption{test}
     \includegraphics[scale=0.75]{img}
-    \label{fig:anlagentest}
+    \label{fig:anlagentest2}
 \end{figure}

--- a/build/tests/main.tex
+++ b/build/tests/main.tex
@@ -13,4 +13,4 @@ Das Template unterstützt auch einen weiteren cite Befehl welcher platzsparender
 \subsection{Bilder Test Subsection}
 
 \dhgefigure[h]{img}{scale=0.25}{Ein Testbild}{fig:test}[Xmisc][S. 17ff]
-\dhgefigure[h]{img}{scale=.6}{Ein Testbild}{fig:test}
+\dhgefigure[h]{img}{scale=.6}{Ein Testbild}{fig:test2}


### PR DESCRIPTION
Die QOL-Branch löscht ``Xarticle`` aus der ``literatur.bib``, weswegen die Zitierung fehlschlägt.

Außerdem wurde das Label ``fig:test`` mehrfach vergeben, was auch Warnings erzeugt, das ist aber scheinbar schon länger so