### PR TITLE
[Fix #117] Quellen zu Bildern sind nur mit Angabe der Seite referenzierbar

### DIFF
--- a/build/components/commands.tex
+++ b/build/components/commands.tex
@@ -9,7 +9,9 @@
         \label{#5}
 
         \ifx #6\empty \else
-            \ifx #7\empty \else
+            \ifx #7\empty
+                {\small \protect \textbf{Quelle:} \cite{#6}}
+            \else
                 {\small \protect \textbf{Quelle:} \cite[#7]{#6}}
             \fi
         \fi


### PR DESCRIPTION
Zum Nachstellen siehe https://github.com/RvNovae/dhge-latex/pull/130#issuecomment-1091445834
Fixes #117