### PR TITLE
Fix Freigabe formatting when using indentations

### DIFF
--- a/build/template.tex
+++ b/build/template.tex
@@ -151,6 +151,9 @@
             \cleardoublepage
         \fi
     \fi
+    
+    \setlength{\parskip}{6pt}
+    \setlength{\parindent}{0cm}
 
     % EHRENWÖRTLICHE ERKLÄRUNG
     \pagestyle{empty}

--- a/build/template.tex
+++ b/build/template.tex
@@ -152,10 +152,12 @@
         \fi
     \fi
     
+    % Einrückung und Abstand unabhängig von config.tex setzen: Ehrenwort und Freigabe korrekt formatiert
     \setlength{\parskip}{6pt}
     \setlength{\parindent}{0cm}
 
     % EHRENWÖRTLICHE ERKLÄRUNG
+
     \pagestyle{empty}
     \pagenumbering{gobble}
     \section*{Ehrenwörtliche Erklärung}


### PR DESCRIPTION
Vor der Ehrenwörtlichen Erklärung und Freigabe werden nun einfach die Einrückungen einfach wieder resettet.
Dadurch wird bei `\def\CEINR {1}` die freigabe nun korrekt dargestellt.