### PR TITLE
Default width für \dhgefigure

### DIFF
--- a/.vscode/tex_snippets.code-snippets
+++ b/.vscode/tex_snippets.code-snippets
@@ -1,8 +1,8 @@
 {
     "DHGE Figure": {
-        "prefix": ["dhgefigure"], // auf welchem namen der snippet auffindbar ist
+        "prefix": ["figure, dhgefigure"], // auf welchem namen der snippet auffindbar ist
         "scope": "latex,tex", // welche files der snippet betreffen soll
-        "body": "\\dhgefigure[${7:tbp}]{${1:filename}}{scale=${6:1.0}}{${2:Caption}}{fig:${3:label}}[${4:biblatex_id}][${5:Postnote}]", // der snippet
+        "body": "\\dhgefigure[${7:tbp}]{${1:filename}}[width=${6:\\textwidth}]{${2:Caption}}{fig:${3:label}}[${4:biblatex_id}][${5:Postnote}]", // der snippet
 
         "description": "Insert \\dhgefigure" // beschreibung
     },

--- a/README.md
+++ b/README.md
@@ -264,14 +264,14 @@ welches einen Überblick über Bilder und ihre Optionen wie z.B. Positionierung 
 ## dhge-latex Abbildungen
 
 ```latex
-\dhgefigure[1]{2}{3}{4}{5}[6][7]
+\dhgefigure[1]{2}[3]{4}{5}[6][7]
 ```
 
 kann mit bis zu sechs Argumenten aufgerufen werden:
 
 1. **Optional** Float Position, standardmäßig `tbp`
 2. Relativer Bild-Pfad mit oder ohne Dateiendung (relativ zum `./assets/img` Ordner, kann in `template.tex` angepasst werden)
-3. `\includegraphics` Optionen (leer lassen für Standard)
+3. `\includegraphics` Optionen (weglassen für Standard (Breite = Textbreite))
 4. Bildunterschrift
 5. Label für die Figure/Grafik
 6. **Optional:** ID
@@ -280,7 +280,10 @@ kann mit bis zu sechs Argumenten aufgerufen werden:
 Beispiel:
 
 ```latex
-\dhgefigure[h]{mapi_outgoing_illustration}{scale=0.75}{Absenden einer MAPI Nachricht}{fig:mapi}[mapi][S. 17ff]
+% allen Optionen (optionale Optionen können sowohl `[]` als auch `{}` sein (hier `[]`), required müssen `{}` sein)
+\dhgefigure[h]{mapi_outgoing_illustration}[scale=0.75]{Absenden einer MAPI Nachricht}{fig:mapi}[mapi][S. 17ff]
+% nur notwendige Optionen
+\dhgefigure{mapi_outgoing_illustration}{Absenden einer MAPI Nachricht}{fig:mapi}
 ```
 
 ***

--- a/build/components/commands.tex
+++ b/build/components/commands.tex
@@ -1,5 +1,5 @@
 % dhgefigure -> ...
-\DeclareDocumentCommand{\dhgefigure}{O{tbp} m m m m O{} O{}}
+\DeclareDocumentCommand{\dhgefigure}{O{tbp} m O{width=\textwidth} m m O{} O{}}
 {
     \begin{figure}[#1]
         \begin{center}

--- a/build/tests/anlagen.tex
+++ b/build/tests/anlagen.tex
@@ -6,7 +6,8 @@
     \end{tabular}
 \end{table}
 
-\dhgefigure[h]{img}{scale=0.25}{Ein Testbild}{fig:anlagentest}[Xmisc][S. 17ff]
+\dhgefigure[h]{img}[scale=0.25]{Ein Testbild}{fig:anlagentest}[Xmisc][S. 17ff]
+\dhgefigure{img}{Ein Testbild}{fig:anlagentest}[Xmisc]
 
 \begin{figure}[H]
     \centering

--- a/build/tests/main.tex
+++ b/build/tests/main.tex
@@ -12,5 +12,5 @@ Das Template unterstützt auch einen weiteren cite Befehl welcher platzsparender
 
 \subsection{Bilder Test Subsection}
 
-\dhgefigure[h]{img}{scale=0.25}{Ein Testbild}{fig:test}[Xmisc][S. 17ff]
-\dhgefigure[h]{img}{scale=.6}{Ein Testbild}{fig:test2}
+\dhgefigure[h]{img}[scale=0.25]{Ein Testbild}{fig:test}[Xmisc][S. 17ff]
+\dhgefigure{img}{Ein Testbild}{fig:test2}


### PR DESCRIPTION
Wie schon der Title sagt wird einfach nur eine default-Breite für den `\dhgefigure` Command hinzugefügt. 
Dadurch kann diese Option ausgelassen werden und wird trotzdem vernünftig in den Text eingefügt. (Snippet wurde entsprechend angepasst)